### PR TITLE
Fix payload ids

### DIFF
--- a/Sources/PublicInterface/Client.swift
+++ b/Sources/PublicInterface/Client.swift
@@ -184,7 +184,7 @@ public class Client: WalletConnect {
             delegate.client(self, didConnect: existingSession)
         } else { // establishing new connection, handshake in process
             communicator.subscribe(on: dAppInfo.peerId, url: url)
-            let request = try! Request(url: url, method: "wc_sessionRequest", params: [dAppInfo], id: UUID().hashValue)
+            let request = try! Request(url: url, method: "wc_sessionRequest", params: [dAppInfo], id: Request.payloadId())
             let requestID = request.internalID!
             responses.add(requestID: requestID) { [unowned self] response in
                 self.handleHandshakeResponse(response)


### PR DESCRIPTION
This PR changes the way payloadIDs are generated, to match the behavior of the JS SDK (see https://github.com/WalletConnect/walletconnect-monorepo/blob/f04bf82d62c66a562040aeec45e822eb16b79fd9/packages/helpers/utils/src/index.ts#L212)

The values generated by `UUID().hashValue` and `UUID().uuidString` are too big for JS to handle it (see below), which breaks the interaction between a Swift client and  JS client (for example a native (d)app connecting to @rainbow-me wallet (which uses React Native and JS).

![Screen Shot 2020-11-03 at 11 51 12 PM](https://user-images.githubusercontent.com/1247834/98076705-cbbd8b80-1e3c-11eb-9a5f-adb4062e0d9f.png)

This fixes #33 

Demo: https://recordit.co/PMdIMST99N