### PR TITLE
Add scheme to client session info

### DIFF
--- a/Sources/PublicInterface/Session.swift
+++ b/Sources/PublicInterface/Session.swift
@@ -42,7 +42,7 @@ public struct Session: Codable {
         public let url: URL
         public let scheme: String?
 
-        public init(name: String, description: String?, icons: [URL], url: URL, scheme: String? ) {
+        public init(name: String, description: String?, icons: [URL], url: URL, scheme: String? = nil ) {
             self.name = name
             self.description = description
             self.icons = icons

--- a/Sources/PublicInterface/Session.swift
+++ b/Sources/PublicInterface/Session.swift
@@ -40,12 +40,14 @@ public struct Session: Codable {
         public let description: String?
         public let icons: [URL]
         public let url: URL
+        public let scheme: String?
 
-        public init(name: String, description: String?, icons: [URL], url: URL) {
+        public init(name: String, description: String?, icons: [URL], url: URL, scheme: String? ) {
             self.name = name
             self.description = description
             self.icons = icons
             self.url = url
+            self.scheme = scheme
         }
     }
 


### PR DESCRIPTION
As discussed in the Mobile 2 Mobile telegram channel, we decided to pass an extra property to the client PeerMeta so wallets can redirect back to the app automatically.

Working example with @rainbow-me: http://recordit.co/60R7Vj3a6E

In this new property, apps should add the scheme they support. For ex. assuming the app scheme is `wcdemo`, it should initialize the client like this: 

```
func connect() -> String {
        let wcUrl =  WCURL(topic: UUID().uuidString,
                           bridgeURL: URL(string: "https://bridge.walletconnect.org")!,
                           key: try! randomKey())
        let clientMeta = Session.ClientMeta(name: "ExampleDApp",
                                            description: "WalletConnectSwift ",
                                            icons: [],
                                            url: URL(string: "https://safe.gnosis.io")!,
                                            scheme: "wcdemo")
        let dAppInfo = Session.DAppInfo(peerId: UUID().uuidString, peerMeta: clientMeta)
        client = Client(delegate: self, dAppInfo: dAppInfo)

        print("WalletConnect URL: \(wcUrl.absoluteString)")

        try! client.connect(to: wcUrl)
        return wcUrl.absoluteString
    }
```


On the wallet side, after handling the request you can simply call
```
UIApplication.shared.open(scheme + "://", options: [:], completionHandler: nil)
```
