### PR TITLE
Remove Starscream as dependency, use Apple's URLSession-based websockets instead

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,1 @@
 github "krzyzanowskim/CryptoSwift" ~> 1.4.0
-github "daltoniam/Starscream" ~> 4.0.4

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "WalletConnectSwift",
     platforms: [
-        .macOS(.v10_14), .iOS(.v11),
+        .macOS(.v10_14), .iOS(.v13),
     ],
     products: [
         .library(
@@ -12,13 +12,12 @@ let package = Package(
             targets: ["WalletConnectSwift"])
     ],
     dependencies: [
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.4.0")),
-        .package(url: "https://github.com/daltoniam/Starscream.git", .upToNextMinor(from: "4.0.4"))
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.4.0"))
     ],
     targets: [
         .target(
             name: "WalletConnectSwift", 
-            dependencies: ["CryptoSwift", "Starscream"],
+            dependencies: ["CryptoSwift"],
             path: "Sources"),
         .testTarget(name: "WalletConnectSwiftTests", dependencies: ["WalletConnectSwift"], path: "Tests"),
     ],

--- a/README.md
+++ b/README.md
@@ -132,13 +132,12 @@ Please open `ExampleApps/ExampleApps.xcodeproj`
 
 ## Prerequisites
 
-- iOS 11.0 or macOS 10.14
+- iOS 13.0 or macOS 10.14
 - Swift 5
 
 ## WalletConnectSwift dependencies
 
 - CryptoSwift - for cryptography operations
-- Starscream - for WebSocket operations prior to iOS 13
 
 ## Swift Package Manager
 
@@ -152,7 +151,7 @@ In your `Package.swift`:
 
 In your `Podfile`:
 
-    platform :ios, '11.0'
+    platform :ios, '13.0'
     use_frameworks!
 
     target 'MyApp' do
@@ -169,7 +168,7 @@ Run `carthage update` to build the framework and drag the WalletConnectSwift.fra
 
 # Acknowledgments
 
-We'd like to thank [Trust Wallet](https://github.com/trustwallet/wallet-connect-swift) team for inspiration in imlpementing this library.
+We'd like to thank [Trust Wallet](https://github.com/trustwallet/wallet-connect-swift) team for inspiration in implementing this library.
 
 # Contributors
 

--- a/Sources/Internal/AES_256_CBC_HMAC_SHA256_Codec.swift
+++ b/Sources/Internal/AES_256_CBC_HMAC_SHA256_Codec.swift
@@ -84,7 +84,7 @@ class AES_256_CBC_HMAC_SHA256_Codec: Codec {
     }
 
     private func authenticationCode(key: Data, data: Data) throws -> Data {
-        let algo = HMAC(key: key.bytes, variant: .sha256)
+        let algo = HMAC(key: key.bytes, variant: .sha2(.sha256))
         let digest = try algo.authenticate(data.bytes)
         return Data(digest)
     }

--- a/Sources/Internal/Communicator.swift
+++ b/Sources/Internal/Communicator.swift
@@ -109,15 +109,16 @@ class Communicator {
 
         func addOrUpdate(_ session: Session) {
             dispatchPrecondition(condition: .notOnQueue(queue))
-            queue.sync { [unowned self] in
-                self.sessions[session.url] = session
+            queue.sync { [weak self] in
+                self?.sessions[session.url] = session
             }
         }
 
         func all() -> [Session] {
             var result: [Session] = []
             dispatchPrecondition(condition: .notOnQueue(queue))
-            queue.sync { [unowned self] in
+            queue.sync { [weak self] in
+                guard let self = self else { return }
                 result = Array(self.sessions.values)
             }
             return result
@@ -126,7 +127,8 @@ class Communicator {
         func find(url: WCURL) -> Session? {
             var result: Session?
             dispatchPrecondition(condition: .notOnQueue(queue))
-            queue.sync { [unowned self] in
+            queue.sync { [weak self] in
+                guard let self = self else { return }
                 result = self.sessions[url]
             }
             return result
@@ -134,8 +136,8 @@ class Communicator {
 
         func remove(url: WCURL) {
             dispatchPrecondition(condition: .notOnQueue(queue))
-            queue.sync { [unowned self] in
-                _ = self.sessions.removeValue(forKey: url)
+            queue.sync { [weak self] in
+                _ = self?.sessions.removeValue(forKey: url)
             }
         }
     }

--- a/Sources/Internal/WebSocketConnection.swift
+++ b/Sources/Internal/WebSocketConnection.swift
@@ -5,10 +5,15 @@
 import Foundation
 import Network
 
+#if os(iOS)
+import UIKit
+#endif
+
 enum WebSocketError: Error {
     case closedUnexpectedly
     case peerDisconnected
 }
+
 
 class WebSocketConnection {
     let url: WCURL

--- a/Sources/Internal/WebSocketConnection.swift
+++ b/Sources/Internal/WebSocketConnection.swift
@@ -124,7 +124,7 @@ class WebSocketConnection {
         guard isConnected else { return }
         task?.send(.string(text)) { [weak self] error in
             if let error = error {
-                self?.handleEvent(.error(error))
+                self?.handleEvent(.connnectionError(error))
             } else {
                 self?.handleEvent(.messageSent(text))
             }
@@ -141,7 +141,6 @@ private extension WebSocketConnection {
         case messageSent(String)
         case pingSent
         case pongReceived
-        case error(Error)
         case connnectionError(Error)
     }
 
@@ -164,7 +163,7 @@ private extension WebSocketConnection {
         guard isConnected else { return }
         task?.sendPing(pongReceiveHandler: { [weak self] error in
             if let error = error {
-                self?.handleEvent(.error(error))
+                self?.handleEvent(.connnectionError(error))
             } else {
                 self?.handleEvent(.pongReceived)
             }
@@ -217,8 +216,6 @@ private extension WebSocketConnection {
             LogService.shared.log("WC: ==> ping")
         case .pongReceived:
             LogService.shared.log("WC: <== pong")
-        case .error(let error):
-            LogService.shared.log("WC: Error: \(error.localizedDescription)")
         case .connnectionError(let error):
             LogService.shared.log("WC: Connection error: \(error.localizedDescription)")
             onDisconnect?(error)

--- a/Sources/PublicInterface/Client.swift
+++ b/Sources/PublicInterface/Client.swift
@@ -12,11 +12,15 @@ public protocol ClientDelegate: AnyObject {
     func client(_ client: Client, didUpdate session: Session)
 }
 
+public protocol Client2Delegate: ClientDelegate {
+    func client(_ client: Client, dappInfoForUrl url: WCURL) -> Session.DAppInfo?
+}
+
 public class Client: WalletConnect {
     public typealias RequestResponse = (Response) -> Void
 
     private(set) weak var delegate: ClientDelegate?
-    private let dAppInfo: Session.DAppInfo
+    private var commonDappInfo: Session.DAppInfo?
     private var responses: Responses
 
     public enum ClientError: Error {
@@ -24,9 +28,9 @@ public class Client: WalletConnect {
         case sessionNotFound
     }
 
-    public init(delegate: ClientDelegate, dAppInfo: Session.DAppInfo) {
+    public init(delegate: ClientDelegate, dAppInfo: Session.DAppInfo? = nil) {
         self.delegate = delegate
-        self.dAppInfo = dAppInfo
+        self.commonDappInfo = dAppInfo
         responses = Responses(queue: DispatchQueue(label: "org.walletconnect.swift.client.pending"))
         super.init()
     }
@@ -185,9 +189,16 @@ public class Client: WalletConnect {
         if let existingSession = communicator.session(by: url) {
             communicator.subscribe(on: existingSession.dAppInfo.peerId, url: existingSession.url)
             delegate?.client(self, didConnect: existingSession)
-        } else { // establishing new connection, handshake in process
-            communicator.subscribe(on: dAppInfo.peerId, url: url)
-            let request = try! Request(url: url, method: "wc_sessionRequest", params: [dAppInfo], id: Request.payloadId())
+        } else {
+            // establishing new connection, handshake in process
+            guard let dappInfo = commonDappInfo ?? (delegate as? Client2Delegate)?.client(self, dappInfoForUrl: url) else {
+                LogService.shared.log("WC: dAppInfo not found for \(url)")
+                delegate?.client(self, didFailToConnect: url)
+                return
+            }
+
+            communicator.subscribe(on: dappInfo.peerId, url: url)
+            let request = try! Request(url: url, method: "wc_sessionRequest", params: [dappInfo], id: Request.payloadId())
             let requestID = request.internalID!
             responses.add(requestID: requestID) { [unowned self] response in
                 self.handleHandshakeResponse(response)
@@ -196,11 +207,16 @@ public class Client: WalletConnect {
         }
     }
 
-
     private func handleHandshakeResponse(_ response: Response) {
         do {
             let walletInfo = try response.result(as: Session.WalletInfo.self)
-            let session = Session(url: response.url, dAppInfo: dAppInfo, walletInfo: walletInfo)
+
+            guard let dappInfo = commonDappInfo ?? (delegate as? Client2Delegate)?.client(self, dappInfoForUrl: response.url) else {
+                LogService.shared.log("WC: dAppInfo not found for \(response.url)")
+                return
+            }
+
+            let session = Session(url: response.url, dAppInfo: dappInfo, walletInfo: walletInfo)
 
             guard walletInfo.approved else {
                 // TODO: handle Error
@@ -326,24 +342,29 @@ public class Client: WalletConnect {
     }
 
     /// https://docs.walletconnect.org/json-rpc-api-methods/ethereum#parameters-4
-    public struct Transaction: Encodable {
-        var from: String
-        var to: String?
-        var data: String
-        var gas: String?
-        var gasPrice: String?
-        var value: String?
-        var nonce: String?
-        var type: String?
-        var accessList: [AccessListItem]?
-        var chainId: String?
-        var maxPriorityFeePerGas: String?
-        var maxFeePerGas: String?
+    public struct Transaction: Codable {
+        public var from: String
+        public var to: String?
+        public var data: String
+        public var gas: String?
+        public var gasPrice: String?
+        public var value: String?
+        public var nonce: String?
+        public var type: String?
+        public var accessList: [AccessListItem]?
+        public var chainId: String?
+        public var maxPriorityFeePerGas: String?
+        public var maxFeePerGas: String?
 
         /// https://eips.ethereum.org/EIPS/eip-2930
-        public struct AccessListItem: Encodable {
-            var address: String
-            var storageKeys: [String]
+        public struct AccessListItem: Codable {
+            public var address: String
+            public var storageKeys: [String]
+
+            public init(address: String, storageKeys: [String]) {
+                self.address = address
+                self.storageKeys = storageKeys
+            }
         }
 
         public init(from: String,

--- a/Sources/PublicInterface/Server.swift
+++ b/Sources/PublicInterface/Server.swift
@@ -28,12 +28,26 @@ public protocol ServerDelegate: AnyObject {
     func server(_ server: Server, didUpdate session: Session)
 }
 
+public protocol ServerDelegateV2: ServerDelegate {
+    /// Replacement for the `server(_:shouldStart:completion:) method that makes possible async approval process.
+    /// When the approval is ready, call the `Server.sendCreateSessionResponse` method.
+    /// If you implement this protocol, the other `shouldStart` method will not be called
+    ///
+    ///
+    /// - Parameters:
+    ///   - server: the server object
+    ///   - requestId: connection request's id. Can be Int, Double, or String
+    ///   - session: the session to create. Contains dapp info received in the connection request.
+    func server(_ server: Server, didReceiveConnectionRequest requestId: RequestID, for session: Session)
+}
+
 open class Server: WalletConnect {
     private let handlers: Handlers
     public private(set) weak var delegate: ServerDelegate?
 
     public enum ServerError: Error {
         case missingWalletInfoInSession
+        case failedToCreateSessionResponse
     }
 
     public init(delegate: ServerDelegate) {
@@ -127,6 +141,32 @@ open class Server: WalletConnect {
         delegate?.server(self, didDisconnect: session)
     }
 
+    /// Sends response for the create session request.
+    /// Use this method together with `ServerDelegate.server(_ server:didReceiveConnectionRequest:for:)`.
+    ///
+    /// - Parameters:
+    ///   - requestId: pass the request id that was received before
+    ///   - session: session with dapp info populated.
+    ///   - walletInfo: the response from the wallet.
+    ///         If approved, you need to create peerId with UUID().uuidString and put it inside the wallet info.
+    public func sendCreateSessionResponse(for requestId: RequestID, session: Session, walletInfo: Session.WalletInfo) {
+        let response: Response
+        do {
+            response = try Response(url: session.url, value: walletInfo, id: requestId)
+        } catch {
+            LogService.shared.log("WC: failed to compose SessionRequest response: \(error)")
+            delegate?.server(self, didFailToConnect: session.url)
+            return
+        }
+        communicator.send(response, topic: session.dAppInfo.peerId)
+        if walletInfo.approved {
+            let updatedSession = Session(url: session.url, dAppInfo: session.dAppInfo, walletInfo: walletInfo)
+            communicator.addOrUpdateSession(updatedSession)
+            communicator.subscribe(on: walletInfo.peerId, url: updatedSession.url)
+            delegate?.server(self, didConnect: updatedSession)
+        }
+    }
+
     /// thread-safe collection of RequestHandlers
     private class Handlers {
         private var handlers: [RequestHandler] = []
@@ -171,20 +211,15 @@ extension Server: HandshakeHandlerDelegate {
     func handler(_ handler: HandshakeHandler,
                  didReceiveRequestToCreateSession session: Session,
                  requestId: RequestID) {
-        delegate?.server(self, shouldStart: session) { [weak self] walletInfo in
-            guard let `self` = self else { return }
-            // TODO: error handling!
-            let response = try! Response(url: session.url, value: walletInfo, id: requestId)
-            self.communicator.send(response, topic: session.dAppInfo.peerId)
-            if walletInfo.approved {
-                let updatedSession = Session(url: session.url, dAppInfo: session.dAppInfo, walletInfo: walletInfo)
-                self.communicator.addOrUpdateSession(updatedSession)
-                self.communicator.subscribe(on: walletInfo.peerId, url: updatedSession.url)
-                self.delegate?.server(self, didConnect: updatedSession)
-            } else {
-                self.communicator.addOrUpdatePendingDisconnectSession(session)
-                self.communicator.disconnect(from: session.url)
-                self.delegate?.server(self, didDisconnect: session)
+        guard let delegate = delegate else { return }
+        if let delegateV2 = delegate as? ServerDelegateV2 {
+            delegateV2.server(self, didReceiveConnectionRequest: requestId, for: session)
+        } else {
+            delegate.server(self, shouldStart: session) { [weak self] walletInfo in
+                guard let `self` = self else {
+                    return
+                }
+                self.sendCreateSessionResponse(for: requestId, session: session, walletInfo: walletInfo)
             }
         }
     }

--- a/Sources/PublicInterface/WalletConnect.swift
+++ b/Sources/PublicInterface/WalletConnect.swift
@@ -127,11 +127,11 @@ open class WalletConnect {
 
     func log(_ request: Request) {
         guard let text = try? request.json().string else { return }
-        LogService.shared.log("WC: <== \(text)")
+        LogService.shared.log("WC: <== [request] \(text)")
     }
 
     func log(_ response: Response) {
         guard let text = try? response.json().string else { return }
-        LogService.shared.log("WC: <== \(text)")
+        LogService.shared.log("WC: <== [response] \(text)")
     }
 }

--- a/WalletConnectSwift.podspec
+++ b/WalletConnectSwift.podspec
@@ -11,11 +11,10 @@ Pod::Spec.new do |spec|
   spec.license      = { :type => "MIT", :file => "LICENSE" }
   spec.author             = { "Andrey Scherbovich" => "andrey@gnosis.io", "Dmitry Bespalov" => "dmitry.bespalov@gnosis.io" }
   spec.cocoapods_version = '>= 1.4.0'
-  spec.platform     = :ios, "11.0"
+  spec.platform     = :ios, "13.0"
   spec.swift_version = "5.0"
   spec.source       = { :git => "https://github.com/WalletConnect/WalletConnectSwift.git", :tag => "#{spec.version}" }
   spec.source_files  = "Sources/**/*.swift"
   spec.requires_arc = true
   spec.dependency "CryptoSwift", "~> 1.4"
-  spec.dependency "Starscream", "~> 4.0.4"
 end

--- a/WalletConnectSwift.xcodeproj/project.pbxproj
+++ b/WalletConnectSwift.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		5520F7C52317C1A600D58B74 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5520F7C42317C1A600D58B74 /* Helpers.swift */; };
 		557CA9B424C1AD05009836F0 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557CA9B324C1AD05009836F0 /* Logger.swift */; };
 		55B7819924A614470036F8E5 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 55B7819824A614470036F8E5 /* CryptoSwift */; };
-		55B7819B24A614470036F8E5 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = 55B7819A24A614470036F8E5 /* Starscream */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,7 +87,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				55B7819924A614470036F8E5 /* CryptoSwift in Frameworks */,
-				55B7819B24A614470036F8E5 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -234,7 +232,6 @@
 			name = WalletConnectSwift;
 			packageProductDependencies = (
 				55B7819824A614470036F8E5 /* CryptoSwift */,
-				55B7819A24A614470036F8E5 /* Starscream */,
 			);
 			productName = WalletConnectSwift;
 			productReference = 0A927850230BFB2600FDCC0D /* WalletConnectSwift.framework */;
@@ -287,7 +284,6 @@
 			mainGroup = 0ABB071B22FC22BA00BC18BB;
 			packageReferences = (
 				55B7819224A613F40036F8E5 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
-				55B7819524A614240036F8E5 /* XCRemoteSwiftPackageReference "Starscream" */,
 			);
 			productRefGroup = 0ABB072522FC22BA00BC18BB /* Products */;
 			projectDirPath = "";
@@ -513,7 +509,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -569,7 +565,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -620,14 +616,6 @@
 				minimumVersion = 1.4.0;
 			};
 		};
-		55B7819524A614240036F8E5 /* XCRemoteSwiftPackageReference "Starscream" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/daltoniam/Starscream.git";
-			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 4.0.4;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -635,11 +623,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 55B7819224A613F40036F8E5 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
 			productName = CryptoSwift;
-		};
-		55B7819A24A614470036F8E5 /* Starscream */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 55B7819524A614240036F8E5 /* XCRemoteSwiftPackageReference "Starscream" */;
-			productName = Starscream;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WalletConnectSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WalletConnectSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,15 +9,6 @@
           "revision": "4b0565384d3c4c588af09e660535b2c7c9bf5b39",
           "version": "1.4.2"
         }
-      },
-      {
-        "package": "Starscream",
-        "repositoryURL": "https://github.com/daltoniam/Starscream.git",
-        "state": {
-          "branch": null,
-          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-          "version": "4.0.4"
-        }
       }
     ]
   },


### PR DESCRIPTION
This PR removes Starscream as dependency in favour of using Apple's `URLSessionWebSocketTask` directly in the `WebSocketConnection` class (see [motivation](https://github.com/WalletConnect/WalletConnectSwift/issues/121)). 

The minimum required iOS version has been updated to iOS 13.0 due `URLSessionWebSocketTask` having been introduced on iOS 13.

I did quite a bit of testing trying to cover various edge cases related to connectivity issues, such as attempting to initiate a new session with no network availability, or having the app lose the connection temporarily. Since it uses `URLSession`'s built-in `waitsForConnectivity` configuration option, I think it now behaves significantly better than what it was before (retrying indefinitely at a very rapid pace, using lots of CPU and memory).

The [disconnect detection issues](https://github.com/WalletConnect/WalletConnectSwift/issues/117) reported in 1.6.2 do not occur with these changes.

Finally, it also addresses the [issue mentioned here](https://github.com/WalletConnect/WalletConnectSwift/pull/81#issuecomment-953346569) that happened with Startscream's native engine (a light wrapper around `URLSessionWebSocketTask`). The solution revolves around  requesting additional background execution time from the OS whenever the app moves to the background, so that the socket can continue working enough time for the wallet peer to accept or reject the session. I tested it particularly with the Metamask app and it worked great.