### PR TITLE
Added new `willReconnect` method to Client and Server delegates

### DIFF
--- a/Sources/PublicInterface/Client.swift
+++ b/Sources/PublicInterface/Client.swift
@@ -10,6 +10,12 @@ public protocol ClientDelegate: AnyObject {
     func client(_ client: Client, didConnect session: Session)
     func client(_ client: Client, didDisconnect session: Session)
     func client(_ client: Client, didUpdate session: Session)
+    func client(_ client: Client, willReconnect session: Session)
+}
+
+extension ClientDelegate {
+    // Default implementation, override if actually needed
+    func client(_ client: Client, willReconnect session: Session) { }
 }
 
 public class Client: WalletConnect {
@@ -289,6 +295,10 @@ public class Client: WalletConnect {
 
     override func didDisconnect(_ session: Session) {
         delegate?.client(self, didDisconnect: session)
+    }
+
+    override func willReconnect(_ session: Session) {
+        delegate?.client(self, willReconnect: session)
     }
 
     /// Thread-safe collection of client reponses

--- a/Sources/PublicInterface/Client.swift
+++ b/Sources/PublicInterface/Client.swift
@@ -10,16 +10,11 @@ public protocol ClientDelegate: AnyObject {
     func client(_ client: Client, didConnect session: Session)
     func client(_ client: Client, didDisconnect session: Session)
     func client(_ client: Client, didUpdate session: Session)
-    func client(_ client: Client, willReconnect session: Session)
-}
-
-extension ClientDelegate {
-    // Default implementation, override if actually needed
-    func client(_ client: Client, willReconnect session: Session) { }
 }
 
 public protocol Client2Delegate: ClientDelegate {
     func client(_ client: Client, dappInfoForUrl url: WCURL) -> Session.DAppInfo?
+    func client(_ client: Client, willReconnect session: Session)
 }
 
 public class Client: WalletConnect {
@@ -314,7 +309,9 @@ public class Client: WalletConnect {
     }
 
     override func willReconnect(_ session: Session) {
-        delegate?.client(self, willReconnect: session)
+        if let delegate = delegate as? Client2Delegate {
+            delegate.client(self, willReconnect: session)
+        }
     }
 
     /// Thread-safe collection of client reponses

--- a/Sources/PublicInterface/Server.swift
+++ b/Sources/PublicInterface/Server.swift
@@ -26,15 +26,6 @@ public protocol ServerDelegate: AnyObject {
 
     /// Called only when the session is updated with intention of the dAppt.
     func server(_ server: Server, didUpdate session: Session)
-
-    /// Called when the session is being reconnected as part of the retry mechanism after the connection
-    /// has been lost due to e.g. bad connectivity.
-    func server(_ server: Server, willReconnect session: Session)
-}
-
-extension ServerDelegate {
-    // Default implementation, override if actually needed
-    func server(_ server: Server, willReconnect session: Session) { }
 }
 
 public protocol ServerDelegateV2: ServerDelegate {
@@ -48,6 +39,10 @@ public protocol ServerDelegateV2: ServerDelegate {
     ///   - requestId: connection request's id. Can be Int, Double, or String
     ///   - session: the session to create. Contains dapp info received in the connection request.
     func server(_ server: Server, didReceiveConnectionRequest requestId: RequestID, for session: Session)
+
+    /// Called when the session is being reconnected as part of the retry mechanism after the connection
+    /// has been lost due to e.g. bad connectivity.
+    func server(_ server: Server, willReconnect session: Session)
 }
 
 open class Server: WalletConnect {
@@ -151,7 +146,9 @@ open class Server: WalletConnect {
     }
 
     override func willReconnect(_ session: Session) {
-        delegate?.server(self, willReconnect: session)
+        if let delegate = delegate as? ServerDelegateV2 {
+            delegate.server(self, willReconnect: session)
+        }
     }
 
     /// Sends response for the create session request.

--- a/Sources/PublicInterface/Server.swift
+++ b/Sources/PublicInterface/Server.swift
@@ -26,6 +26,15 @@ public protocol ServerDelegate: AnyObject {
 
     /// Called only when the session is updated with intention of the dAppt.
     func server(_ server: Server, didUpdate session: Session)
+
+    /// Called when the session is being reconnected as part of the retry mechanism after the connection
+    /// has been lost due to e.g. bad connectivity.
+    func server(_ server: Server, willReconnect session: Session)
+}
+
+extension ServerDelegate {
+    // Default implementation, override if actually needed
+    func server(_ server: Server, willReconnect session: Session) { }
 }
 
 open class Server: WalletConnect {
@@ -125,6 +134,10 @@ open class Server: WalletConnect {
 
     override func didDisconnect(_ session: Session) {
         delegate?.server(self, didDisconnect: session)
+    }
+
+    override func willReconnect(_ session: Session) {
+        delegate?.server(self, willReconnect: session)
     }
 
     /// thread-safe collection of RequestHandlers

--- a/Sources/PublicInterface/WalletConnect.swift
+++ b/Sources/PublicInterface/WalletConnect.swift
@@ -94,8 +94,8 @@ open class WalletConnect {
         }
         // if a session was not initiated by the wallet or the dApp to disconnect, try to reconnect it.
         guard communicator.pendingDisconnectSession(by: url) != nil else {
-            // TODO: should we notify delegate that we try to reconnect?
             LogService.shared.log("WC: trying to reconnect session by url: \(url.bridgeURL.absoluteString)")
+            willReconnect(session)
             try! reconnect(to: session)
             return
         }
@@ -122,6 +122,10 @@ open class WalletConnect {
     }
 
     func didDisconnect(_ session: Session) {
+        preconditionFailure("Should be implemented in subclasses")
+    }
+
+    func willReconnect(_ session: Session) {
         preconditionFailure("Should be implemented in subclasses")
     }
 


### PR DESCRIPTION
With this new delegate method it should be possible for API users to track the actual connection status of each session. This is helpful when you'd want your UI to reflect whenever a session has lost its connection and thus wallet connect events won't work until it's been reconnected.

It'd work like this:
- Assume all sessions are in disconnected state by default
- on delegate's didConnect method update state to connected
- on delegate's willReconnect method update state to disconnected