### PR TITLE
Fix macOS minimum version to 10.15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "WalletConnectSwift",
     platforms: [
-        .macOS(.v10_14), .iOS(.v13),
+        .macOS(.v10_15), .iOS(.v13),
     ],
     products: [
         .library(


### PR DESCRIPTION
Even though this library is only meant to be used on iOS, when
importing it into another Swift Package Manager this issue appears, as
the min macOS version specified is 10.14 but should be 10.15.

Issue https://github.com/WalletConnect/WalletConnectSwift/issues/130