### PR TITLE
fix: timer thread and crash in communicator

### DIFF
--- a/Sources/Internal/Communicator.swift
+++ b/Sources/Internal/Communicator.swift
@@ -100,7 +100,7 @@ class Communicator {
 
     /// Thread-safe collection of Sessions
     private class Sessions {
-        private var sessions: [WCURL: Session] = [:]
+        private var sessions: [String: Session] = [:]
         private let queue: DispatchQueue
 
         init(queue: DispatchQueue) {
@@ -109,8 +109,9 @@ class Communicator {
 
         func addOrUpdate(_ session: Session) {
             dispatchPrecondition(condition: .notOnQueue(queue))
+            let key = session.url.absoluteString
             queue.sync { [weak self] in
-                self?.sessions[session.url] = session
+                self?.sessions[key] = session
             }
         }
 
@@ -127,17 +128,19 @@ class Communicator {
         func find(url: WCURL) -> Session? {
             var result: Session?
             dispatchPrecondition(condition: .notOnQueue(queue))
+            let key = url.absoluteString
             queue.sync { [weak self] in
                 guard let self = self else { return }
-                result = self.sessions[url]
+                result = self.sessions[key]
             }
             return result
         }
 
         func remove(url: WCURL) {
             dispatchPrecondition(condition: .notOnQueue(queue))
+            let key = url.absoluteString
             queue.sync { [weak self] in
-                _ = self?.sessions.removeValue(forKey: url)
+                _ = self?.sessions.removeValue(forKey: key)
             }
         }
     }

--- a/Sources/Internal/WebSocketConnection.swift
+++ b/Sources/Internal/WebSocketConnection.swift
@@ -96,7 +96,9 @@ class WebSocketConnection {
 
     deinit {
         session.invalidateAndCancel()
-        pingTimer?.invalidate()
+        DispatchQueue.main.async {
+            self.pingTimer?.invalidate()
+        }
 
     #if os(iOS)
         if let observer = self.foregroundNotificationObserver {
@@ -120,7 +122,9 @@ class WebSocketConnection {
     }
 
     func close(closeCode: URLSessionWebSocketTask.CloseCode = .normalClosure) {
-        pingTimer?.invalidate()
+        DispatchQueue.main.async {
+            self.pingTimer?.invalidate()
+        }
         task?.cancel(with: closeCode, reason: nil)
         task = nil
     }
@@ -193,7 +197,9 @@ private extension WebSocketConnection {
         case .disconnected(let closeCode):
             guard isConnected else { break }
             isConnected = false
-            pingTimer?.invalidate()
+            DispatchQueue.main.async {
+                self.pingTimer?.invalidate()
+            }
 
             var error: Error? = nil
             switch closeCode {
@@ -240,7 +246,9 @@ private extension WebSocketConnection {
             webSocketTask: URLSessionWebSocketTask,
             didOpenWithProtocol protocol: String?
         ) {
-            self.connectivityCheckTimer?.invalidate()
+            DispatchQueue.main.async {
+                self.connectivityCheckTimer?.invalidate()
+            }
             eventHandler(.connected)
         }
 

--- a/Sources/Internal/WebSocketConnection.swift
+++ b/Sources/Internal/WebSocketConnection.swift
@@ -96,9 +96,7 @@ class WebSocketConnection {
 
     deinit {
         session.invalidateAndCancel()
-        DispatchQueue.main.async {
-            self.pingTimer?.invalidate()
-        }
+        self.pingTimer?.invalidate()
 
     #if os(iOS)
         if let observer = self.foregroundNotificationObserver {


### PR DESCRIPTION
https://developer.apple.com/documentation/foundation/nstimer/1415405-invalidate
You must send this message from the thread on which the timer was installed. If you send this message from another thread, the input source associated with the timer may not be removed from its run loop, which could prevent the thread from exiting properly.