### PR TITLE
Add more control over Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ if let error = response.error { // NSError
 
 For more details, see the `ExampleApps/ClientApp`
 
+## Logs
+
+Filter the type of logs being printed by changing the log level `LogService.level = .info`.
+
 # Running Example Apps
 
 Please open `ExampleApps/ExampleApps.xcodeproj`

--- a/Sources/Internal/UpdateSessionHandler.swift
+++ b/Sources/Internal/UpdateSessionHandler.swift
@@ -24,7 +24,7 @@ class UpdateSessionHandler: RequestHandler {
             let sessionInfo = try request.parameter(of: SessionInfo.self, at: 0)
             delegate?.handler(self, didUpdateSessionByURL: request.url, sessionInfo: sessionInfo)
         } catch {
-            LogService.shared.log("WC: wrong format of wc_sessionUpdate request: \(error)")
+            LogService.shared.error("WC: wrong format of wc_sessionUpdate request: \(error)")
             // TODO: send error response
         }
     }

--- a/Sources/PublicInterface/Client.swift
+++ b/Sources/PublicInterface/Client.swift
@@ -185,7 +185,7 @@ public class Client: WalletConnect {
     }
 
     override func onConnect(to url: WCURL) {
-        LogService.shared.log("WC: client didConnect url: \(url.bridgeURL.absoluteString)")
+        LogService.shared.info("WC: client didConnect url: \(url.bridgeURL.absoluteString)")
         delegate?.client(self, didConnect: url)
         if let existingSession = communicator.session(by: url) {
             communicator.subscribe(on: existingSession.dAppInfo.peerId, url: existingSession.url)
@@ -193,7 +193,7 @@ public class Client: WalletConnect {
         } else {
             // establishing new connection, handshake in process
             guard let dappInfo = commonDappInfo ?? (delegate as? ClientDelegateV2)?.client(self, dappInfoForUrl: url) else {
-                LogService.shared.log("WC: dAppInfo not found for \(url)")
+                LogService.shared.error("WC: dAppInfo not found for \(url)")
                 delegate?.client(self, didFailToConnect: url)
                 return
             }
@@ -213,7 +213,7 @@ public class Client: WalletConnect {
             let walletInfo = try response.result(as: Session.WalletInfo.self)
 
             guard let dappInfo = commonDappInfo ?? (delegate as? ClientDelegateV2)?.client(self, dappInfoForUrl: response.url) else {
-                LogService.shared.log("WC: dAppInfo not found for \(response.url)")
+                LogService.shared.error("WC: dAppInfo not found for \(response.url)")
                 return
             }
 
@@ -289,7 +289,7 @@ public class Client: WalletConnect {
             let info = try request.parameter(of: SessionInfo.self, at: 0)
             return info
         } catch {
-            LogService.shared.log("WC: incoming approval cannot be parsed: \(error)")
+            LogService.shared.error("WC: incoming approval cannot be parsed: \(error)")
             return nil
         }
     }

--- a/Sources/PublicInterface/Logger.swift
+++ b/Sources/PublicInterface/Logger.swift
@@ -7,21 +7,61 @@
 //
 
 import Foundation
+import os.log
+
+public enum LoggerLevel: Int {
+    case none = 0
+    case error = 100
+    case info = 200
+    case detailed = 300
+    case verbose = 400
+}
 
 public protocol Logger {
-    func log(_ message: String)
+    func error(_ message: String)
+    func info(_ message: String)
+    func detailed(_ message: String)
+    func verbose(_ message: String)
 }
 
 public class ConsoleLogger: Logger {
-    public func log(_ message: String) {
-        print(message)
+    static var consoleLogger: OSLog = OSLog(subsystem: "com.walletconnect", category: "WalletConnectSwift")
+
+    public func error(_ message: String) {
+        log(message, level: .error)
+    }
+
+    public func info(_ message: String) {
+        log(message, level: .info)
+    }
+
+    public func detailed(_ message: String) {
+        log(message, level: .detailed)
+    }
+
+    public func verbose(_ message: String) {
+        log(message, level: .verbose)
+    }
+
+    func log(_ message: String, level: LoggerLevel) {
+#if DEBUG
+        guard level.rawValue <= LogService.level.rawValue else { return }
+
+        os_log(
+            "%{private}@",
+            log: ConsoleLogger.consoleLogger,
+            type: OSLogType.debug,
+            message
+        )
+#endif
     }
 }
 
-public class NullLooger: Logger {
-    public func log(_ message: String) { /* ignore */ }
-}
-
+/// Determine the log level by changing the `level` property.
 public class LogService {
-    public static var shared: Logger = ConsoleLogger()
+    static var shared: Logger = ConsoleLogger()
+
+    /// Defines which logs are presented. Defaults to ``LoggerLevel/verbose``
+    /// - Note: Logs are only available in debug mode
+    public static var level: LoggerLevel = .verbose
 }

--- a/Sources/PublicInterface/Server.swift
+++ b/Sources/PublicInterface/Server.swift
@@ -103,15 +103,16 @@ open class Server: WalletConnect {
             log(request)
             handle(request)
         } catch {
-            LogService.shared.log(
-                "WC: incomming text deserialization to JSONRPC 2.0 requests error: \(error.localizedDescription)")
+            LogService.shared.error(
+                "WC: incomming text deserialization to JSONRPC 2.0 requests error: \(error.localizedDescription)"
+            )
             // TODO: handle error
             try! send(Response(url: url, error: .invalidJSON))
         }
     }
 
     override func onConnect(to url: WCURL) {
-        LogService.shared.log("WC: didConnect url: \(url.bridgeURL.absoluteString)")
+        LogService.shared.info("WC: didConnect url: \(url.bridgeURL.absoluteString)")
         if let session = communicator.session(by: url) { // reconnecting existing session
             communicator.subscribe(on: session.walletInfo!.peerId, url: session.url)
             delegate?.server(self, didConnect: session)
@@ -164,7 +165,7 @@ open class Server: WalletConnect {
         do {
             response = try Response(url: session.url, value: walletInfo, id: requestId)
         } catch {
-            LogService.shared.log("WC: failed to compose SessionRequest response: \(error)")
+            LogService.shared.error("WC: failed to compose SessionRequest response: \(error)")
             delegate?.server(self, didFailToConnect: session.url)
             return
         }

--- a/Sources/PublicInterface/WalletConnect.swift
+++ b/Sources/PublicInterface/WalletConnect.swift
@@ -86,7 +86,7 @@ open class WalletConnect {
     ///   - url: WalletConnect url
     ///   - error: error that triggered the disconnection
     private func onDisconnect(from url: WCURL, error: Error?) {
-        LogService.shared.log("WC: didDisconnect url: \(url.bridgeURL.absoluteString)")
+        LogService.shared.info("WC: didDisconnect url: \(url.bridgeURL.absoluteString)")
         // check if disconnect happened during handshake
         guard let session = communicator.session(by: url) else {
             failedToConnect(url)
@@ -94,7 +94,7 @@ open class WalletConnect {
         }
         // if a session was not initiated by the wallet or the dApp to disconnect, try to reconnect it.
         guard communicator.pendingDisconnectSession(by: url) != nil else {
-            LogService.shared.log("WC: trying to reconnect session by url: \(url.bridgeURL.absoluteString)")
+            LogService.shared.info("WC: trying to reconnect session by url: \(url.bridgeURL.absoluteString)")
             willReconnect(session)
             try! reconnect(to: session)
             return
@@ -131,11 +131,16 @@ open class WalletConnect {
 
     func log(_ request: Request) {
         guard let text = try? request.json().string else { return }
-        LogService.shared.log("WC: <== [request] \(text)")
+        LogService.shared.detailed("WC: <== [request] \(text)")
     }
 
     func log(_ response: Response) {
         guard let text = try? response.json().string else { return }
-        LogService.shared.log("WC: <== [response] \(text)")
+
+        if text.contains("\"error\"") {
+            LogService.shared.error("WC: <== [response] \(text)")
+        } else {
+            LogService.shared.detailed("WC: <== [response] \(text)")
+        }
     }
 }


### PR DESCRIPTION
Logs can now be filtered by error, info, detailed, verbose or disabled

This should help developers have more control over what they wish to see, preventing spams, such as ping-pong, or accidentally shipping an app whilst printing too much information. Logs are now only available on debug mode.

Resolves issue https://github.com/WalletConnect/WalletConnectSwift/issues/134

Please note that we should also merge https://github.com/WalletConnect/WalletConnectSwift/pull/131 to fix compatibility issues with other SDK's.