### PR TITLE
Update CryptoSwift to 1.6.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["WalletConnectSwift"])
     ],
     dependencies: [
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.5.1"))
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.6.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Currently, dependency on CryptoSwift is limited to <1.5.1
This conflicts when used in same repository with [Boilertalk/Web3](https://github.com/Boilertalk/Web3.swift/blob/master/Package.swift#L29) which limits to >=1.6.0