### PR TITLE
Allow any characters in the message to be signed

### DIFF
--- a/Sources/PublicInterface/Client.swift
+++ b/Sources/PublicInterface/Client.swift
@@ -83,7 +83,7 @@ public class Client: WalletConnect {
                               message: String,
                               account: String,
                               completion: @escaping RequestResponse) throws {
-        let messageHex = "0x" + message.data(using: .utf8)!.map { String(format: "%02x", $0) }.joined()
+        let messageHex = "0x" + message.compactMap({$0.unicodeScalars.first?.value}).map { String(format: "%02x", $0) }.joined()
         try sign(url: url, method: "personal_sign", param1: messageHex, param2: account, completion: completion)
     }
 


### PR DESCRIPTION
UnstoppableDomains site requires signature of messages in the form of hex hash:

`0x070678b2c6913be3e6a50a10aabfd5ec2513fa6dff0219c2f53d0222d35478fa
`
This fix will allow such messages to be signed.

This is an extending, not a breaking change.